### PR TITLE
fix link to Barret's data science as atomic habit

### DIFF
--- a/references.bib
+++ b/references.bib
@@ -6098,7 +6098,7 @@ URL = {https://arxiv.org/abs/2210.08383},
 	author       = {Malcolm Barrett},
 	year         = 2021,
 	title        = {Data science as an atomic habit},
-	url          = {https://malco.io/2021/01/04/data-science-as-an-atomic-habit/},
+	url          = {https://malco.io/articles/2021-01-04-data-science-as-an-atomic-habit},
 	note         = {16 January},
 }
 @misc{manskiwow,


### PR DESCRIPTION
Fix link to Data science as an atomic habit