### PR TITLE
Fixed Year in Chapter 2 Tutorial

### DIFF
--- a/02-drinking_from_a_fire_hose.qmd
+++ b/02-drinking_from_a_fire_hose.qmd
@@ -1308,4 +1308,4 @@ cleaned_elections_data <-
 
 Then recode the party names from French to English to match what we simulated.
 
-At this point we can make a nice graph of the number of ridings won by each party in the 2019 Canadian Federal Election.
+At this point we can make a nice graph of the number of ridings won by each party in the 2021 Canadian Federal Election.


### PR DESCRIPTION
The beginning of the Chapter 2 tutorial mentions that we are looking at the 2021 Canadian Federal Election. However, in the last sentence it says "2019 Canadian Federal Election". I updated the year to 2021. 